### PR TITLE
feat: update partial tag names to follow Django convention

### DIFF
--- a/src/template_partials/templatetags/partials.py
+++ b/src/template_partials/templatetags/partials.py
@@ -74,8 +74,7 @@ def partialdef_func(parser, token):
     Stores the nodelist in the context under the key "partial_contents" and can
     be retrieved using the {% partial %} tag.
     """
-    _define_partial(parser, token, "endpartialdef")
-    return DefinePartialNode
+    return _define_partial(parser, token, "endpartialdef")
 
 @register.tag(name="startpartial")
 def startpartial_func(parser, token):
@@ -83,8 +82,7 @@ def startpartial_func(parser, token):
         "The 'startpartial' tag is deprecated; use 'partialdef' instead.",
         DeprecationWarning
     )
-    _define_partial(parser, token, "endpartial")
-    return DefinePartialNode
+    return _define_partial(parser, token, "endpartial")
 
 def _define_partial(parser, token, end_tag):
     try:

--- a/tests/templates/debug.html
+++ b/tests/templates/debug.html
@@ -1,8 +1,8 @@
 {% load partials %}
 
-{% startpartial test-partial %}
+{% partialdef test-partial %}
     {{ exception }}
-{% endpartial %}
+{% endpartialdef %}
 
 
 {% block main %}

--- a/tests/templates/example.html
+++ b/tests/templates/example.html
@@ -1,8 +1,8 @@
 {% load partials %}
 
-{% startpartial test-partial %}
+{% partialdef test-partial %}
 TEST-PARTIAL-CONTENT
-{% endpartial %}
+{% endpartialdef %}
 
 
 {% block main %}


### PR DESCRIPTION
- Rename 'startpartial' to 'partialdef'
- Update corresponding end tag to 'endpartialdef'
- Alias old 'startpartial' and add a DeprecationWarning when used
- Update existing test_partial_tags test case
- Add test_deprecated_startpartial_tag test case

BREAKING CHANGE: The tag name 'startpartial' is deprecated and will be removed in future versions. Use 'partialdef' instead.

Fixes issue #12 - templatetag incompatible with IntelliJ editors.