### PR TITLE
Remove unnecessary `pass` in the partials.py module

### DIFF
--- a/src/template_partials/templatetags/partials.py
+++ b/src/template_partials/templatetags/partials.py
@@ -130,5 +130,3 @@ def partial_func(parser, token):
         )
 
     return RenderPartialNode(partial_name, origin=parser.origin)
-
-    pass


### PR DESCRIPTION
Remove unnecessary `pass` in the partials.py module