### PR TITLE
Fixed unsuccessful template loader wrapping

### DIFF
--- a/src/template_partials/apps.py
+++ b/src/template_partials/apps.py
@@ -3,6 +3,9 @@ django-template-partials
 
 App configuration to set up a partials loader automatically.
 """
+from contextlib import suppress
+import django.template
+import django.contrib.admin
 from django.apps import AppConfig
 from django.conf import settings
 
@@ -32,6 +35,11 @@ def wrap_loaders(name):
                 partial_loaders = [("template_partials.loader.Loader", cached_loaders)]
                 template_config["OPTIONS"]["loaders"] = partial_loaders
             break
+
+    # Force re-evaluation of settings.TEMPLATES because EngineHandler caches it.
+    with suppress(AttributeError):
+        del django.template.engines.templates
+        django.template.engines._engines = {}
 
 
 class LoaderAppConfig(AppConfig):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,31 @@
 import warnings
 
-from django.template import engines
-from django.test import TestCase
+import django.template
+from django.test import TestCase, override_settings
+from django.template import engines, EngineHandler
+
+from template_partials.apps import wrap_loaders
+
+
+@override_settings(
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "APP_DIRS": True,
+        },
+    ]
+)
+class SimpleAppConfigTestCase(TestCase):
+    def test_wrap_loaders(self):
+        django.template.engines = EngineHandler()
+
+        outermost_loader = django.template.engines["django"].engine.loaders[0][0]
+        assert outermost_loader != "template_partials.loader.Loader"
+
+        wrap_loaders("django")
+
+        outermost_loader = django.template.engines["django"].engine.loaders[0][0]
+        assert outermost_loader == "template_partials.loader.Loader"
 
 
 class PartialTagsTestCase(TestCase):


### PR DESCRIPTION
If `template_partials` is not the first entry in `settings.INSTALLED_APPS`, the template engine's loaders might be set already due to another app importing `django.template`. For example, if `slippers` comes before `template_partials`.

In that case, `wrap_loader()` needs to clear the cached engine definitions and force EngineHandler to read the settings again.