### PR TITLE
Try to re-use settings.py template loader config before using defaults

### DIFF
--- a/src/template_partials/apps.py
+++ b/src/template_partials/apps.py
@@ -25,10 +25,13 @@ def wrap_loaders(name):
             )
             if not already_configured:
                 template_config.pop("APP_DIRS", None)
-                default_loaders = [
-                    "django.template.loaders.filesystem.Loader",
-                    "django.template.loaders.app_directories.Loader",
-                ]
+                try:
+                    default_loaders = loaders[0][1]
+                except IndexError:
+                    default_loaders = [
+                        "django.template.loaders.filesystem.Loader",
+                        "django.template.loaders.app_directories.Loader",
+                    ]
                 cached_loaders = [
                     ("django.template.loaders.cached.Loader", default_loaders)
                 ]


### PR DESCRIPTION
Fix #30 

wrap_loaders checks if `loaders[0][0] == "template_partials.loader.Loader"`. Which it doesn't if you had set TEMPLATES["OPTIONS"]["loaders"] to anything else. django-components suggests you do this [in the installation section](https://github.com/EmilStenstrom/django-components?tab=readme-ov-file#installation):

```py
TEMPLATES = [
    {
        ...,
        'OPTIONS': {
            'context_processors': [
                ...
            ],
            'loaders':[(
                'django.template.loaders.cached.Loader', [
                    'django.template.loaders.filesystem.Loader',
                    'django.template.loaders.app_directories.Loader',
                    'django_components.template_loader.Loader',
                ]
            )],
        },
    },
]
```

So `loaders[0][0]` is actually "django.template.loaders.cached.Loader". Then wrap_loaders overrides it:

```
            already_configured = (
                loaders
                and isinstance(loaders, (list, tuple))
                and isinstance(loaders[0], tuple)
                and loaders[0][0] == "template_partials.loader.Loader"
            )
            if not already_configured:
                template_config.pop("APP_DIRS", None)
                default_loaders = [
                    "django.template.loaders.filesystem.Loader",
                    "django.template.loaders.app_directories.Loader",
                ]
                cached_loaders = [
                    ("django.template.loaders.cached.Loader", default_loaders)
                ]
                partial_loaders = [("template_partials.loader.Loader", cached_loaders)]
                template_config["OPTIONS"]["loaders"] = partial_loaders
            break
```

So the easy fix for anyone running into this is to wrap it yourself:

```py
...
        "OPTIONS": {
            'loaders': [(
                'template_partials.loader.Loader', [(
                    'django.template.loaders.cached.Loader', [
                        'django.template.loaders.filesystem.Loader',
                        'django.template.loaders.app_directories.Loader',
                        'django_components.template_loader.Loader',
                    ])
                ]
            )],
...
```

This does that by default by `wrap_loaders` and uses the default config as a fallback.