### PR TITLE
Calling first level child loader directly if it's a `django.template.loaders.cached.Loader`

### DIFF
--- a/src/template_partials/loader.py
+++ b/src/template_partials/loader.py
@@ -1,3 +1,4 @@
+from django.template.loaders import cached
 from django.template import TemplateDoesNotExist
 from django.template.loaders.base import Loader as BaseLoader
 
@@ -34,7 +35,11 @@ class Loader(BaseLoader):
         template_name, _, partial_name = template_name.partition("#")
 
         # May raise TemplateDoesNotExist
-        template = super().get_template(template_name, skip)
+        # Some loaders require to be called directly (specifically the django.templates.loaders.cached.Loader)
+        if len(self.loaders) == 1 and isinstance(self.loaders[0], cached.Loader):
+            template = self.loaders[0].get_template(template_name, skip)
+        else:
+            template = super().get_template(template_name, skip)
 
         if not partial_name:
             return template


### PR DESCRIPTION
Fixes #36 