### PR TITLE
Fixed #39 -- Handle loader reset when a template change is detected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 24.2 (2024-04-08)
+
+* Implemented ``reset()`` on the partial loader to pass down to child loaders  
+  when the autoreloader detects a template change. This allows the cached loader 
+  to be correctly cleared in development. 
+
+  (The underlying issue here was masked prior to v24.1.) 
+
 ## 24.1 (2024-04-04)
 
 * Fixed a bug in how the partial loader called down to the cached loader when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = ["Django"]
 
 [project.urls]
 Repository = "https://github.com/carltongibson/django-template-partials/"
+Changelog = "https://github.com/carltongibson/django-template-partials/blob/main/CHANGELOG.md"
 # Docs = "https://noumenal.es/django-template-partials/"
 
 [project.optional-dependencies]

--- a/src/template_partials/__init__.py
+++ b/src/template_partials/__init__.py
@@ -4,4 +4,4 @@ django-template-partials
 Reusable named inline-partials for the Django Template Language.
 """
 
-__version__ = "24.1"
+__version__ = "24.2"

--- a/src/template_partials/loader.py
+++ b/src/template_partials/loader.py
@@ -62,3 +62,10 @@ class Loader(BaseLoader):
     def get_template_sources(self, template_name):
         for loader in self.loaders:
             yield from loader.get_template_sources(template_name)
+
+    def reset(self):
+        for loader in self.loaders:
+            try:
+                loader.reset()
+            except AttributeError:
+                pass

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,5 @@
 import warnings
+from pathlib import Path
 
 import django.template
 from django.test import TestCase, override_settings
@@ -150,5 +151,9 @@ class ChildCachedLoaderTest(TestCase):
             type(cached_loader).__module__, "django.template.loaders.cached"
         )
         self.assertEqual(len(cached_loader.get_template_cache), 0)
-        engine.get_template("example.html")
+        template = engine.get_template("example.html")
         self.assertEqual(len(cached_loader.get_template_cache), 1)
+
+        # Simulate a template change and check the cache is reset.
+        django.template.autoreload.template_changed(None, Path(template.origin.name))
+        self.assertEqual(len(cached_loader.get_template_cache), 0)


### PR DESCRIPTION
Pass reset() call down to child loaders. Fixes #39. 