### PR TITLE
Added a gentle warning when using quoted partial names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+* Added a gentle warning when using quoted partial names.
+
 ## 24.2 (2024-04-08)
 
 * Implemented ``reset()`` on the partial loader to pass down to child loaders  

--- a/src/template_partials/templatetags/partials.py
+++ b/src/template_partials/templatetags/partials.py
@@ -43,6 +43,13 @@ class DefinePartialNode(template.Node):
         self.inline = inline
         self.nodelist = nodelist
 
+        if self.partial_name and self.partial_name[0] in "'\"":
+            warnings.warn(
+                f"You are using a quoted partial name ({self.partial_name}). This is not intended.",
+                RuntimeWarning,
+                stacklevel=1,
+            )
+
     def render(self, context):
         """Set content into context and return empty string"""
         if self.inline:


### PR DESCRIPTION
I felt stupid today when debugging **again** why the partial wasn't known. Turns out, I have been quoting the name again. This wasn't the first time. Maybe a gentle warning would be nice? Maybe this could even be a `TemplateSyntaxError` but it felt a little bit harsh.

By the way, you're only using the black formatter through the VS code plugin it seems. Would you be interested in adding ruff or black via pre-commit? And maybe an `.editorconfig` file. `trim_trailing_whitespace = true` would be helpful. Happy to do the work.