### PR TITLE
Allowed specifying the partial name in the endpartial tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # CHANGELOG
 
 * Added official Django 5.1 support.
+* Allowed adding the partial name to the `endpartialdef` tag, similar to how
+  `endblock` allows specifying the block name again.
 
 ## 24.2 (2024-04-08)
 
-* Implemented ``reset()`` on the partial loader to pass down to child loaders  
-  when the autoreloader detects a template change. This allows the cached loader 
-  to be correctly cleared in development. 
+* Implemented ``reset()`` on the partial loader to pass down to child loaders
+  when the autoreloader detects a template change. This allows the cached loader
+  to be correctly cleared in development.
 
-  (The underlying issue here was masked prior to v24.1.) 
+  (The underlying issue here was masked prior to v24.1.)
 
 ## 24.1 (2024-04-04)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ TEST-PARTIAL-CONTENT
 {% endpartialdef %}
 ```
 
+For extra readability, you can optionally add the name to your `{% endblock %}` tag. For
+example:
+
+```html
+{% load partials %}
+
+{% partialdef test-partial %}
+TEST-PARTIAL-CONTENT
+{% endpartialdef test-partial %}
+```
+
 ### Fragment Re-use
 
 With the partial defined, you can reuse it multiple times later:

--- a/src/template_partials/templatetags/partials.py
+++ b/src/template_partials/templatetags/partials.py
@@ -72,7 +72,7 @@ def partialdef_func(parser, token):
 
     Usage:
 
-        {% partialdef "partial_name" %}
+        {% partialdef partial_name %}
 
         Partial content goes here
 
@@ -116,7 +116,11 @@ def _define_partial(parser, token, end_tag):
         inline = False
 
     # Parse the content until the end tag (`endpartialdef` or deprecated `endpartial`)
-    nodelist = parser.parse((end_tag,))
+    acceptable_endpartials = (end_tag, f"{end_tag} {partial_name}")
+    nodelist = parser.parse(acceptable_endpartials)
+    endpartial = parser.next_token()
+    if endpartial.contents not in acceptable_endpartials:
+        parser.invalid_block_tag(endpartial, "endpartial", acceptable_endpartials)
     parser.delete_first_token()
 
     if not hasattr(parser.origin, "partial_contents"):


### PR DESCRIPTION
I hope it's not too much :) but I thought I'd try implementing this. I do not use `{% endblock block-name %}` all that often, but when I do I find it really useful. `{% endpartial partial-name %}` would probably help as well.

While at it, I also removed the quote characters from `partialdef` uses in the existing testsuite and code.

