### PR TITLE
Fixed #45 -- Deprecated passing the inline argument as inline=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ conventions. (All the built-in tags follow the `<name>` `end<name>` pattern.)
 
   Thanks to George Hickman.
 
+  Note: Passing `inline=True` has been deprecated in 24.5. Only pass `inline` instead.
+
 * Adding `"template_partials"` to `INSTALLED_APPS` will now **automatically** configure
   the partials template loader.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+* Deprecated passing arguments to the `inline` argument of the `partialdef`
+  tag. Either use `inline` or nothing.
+
 ## 24.4 (2024-08-16)
 
 * Fixed a regression in 24.3 for inline partials with wrapping content.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ the content inside your partial, use the `inline` argument in that situation:
 
 ```html
 {% block main %}
-{% partialdef inline-partial inline=True %}
+{% partialdef inline-partial inline %}
 CONTENT
 {% endpartialdef %}
 {% endblock main %}

--- a/src/template_partials/templatetags/partials.py
+++ b/src/template_partials/templatetags/partials.py
@@ -81,7 +81,7 @@ def partialdef_func(parser, token):
     Stores the nodelist in the context under the key "partial_contents" and can
     be retrieved using the {% partial %} tag.
 
-    The optional inline=True argument will render the contents of the partial
+    The optional ``inline`` argument will render the contents of the partial
     where it is defined.
     """
     return _define_partial(parser, token, "endpartialdef")
@@ -114,6 +114,12 @@ def _define_partial(parser, token, end_tag):
     except IndexError:
         # the inline argument is optional, so fallback to not using it
         inline = False
+
+    if inline and inline != "inline":
+        warnings.warn(
+            "The 'inline' argument does not have any parameters; either use 'inline' or remove it completely.",
+            DeprecationWarning,
+        )
 
     # Parse the content until the end tag (`endpartialdef` or deprecated `endpartial`)
     acceptable_endpartials = (end_tag, f"{end_tag} {partial_name}")

--- a/tests/templates/example.html
+++ b/tests/templates/example.html
@@ -13,6 +13,6 @@ MIDDLE
 END
 {% endblock main %}
 
-{% partialdef inline-partial inline=True %}
+{% partialdef inline-partial inline %}
 INLINE-CONTENT
 {% endpartialdef %}


### PR DESCRIPTION
I have changed my current project to use `inline` everywhere instead of `inline=True`, it does look nicer.

I didn't change the `CHANGELOG` mention when the inline argument was introduced; I don't know if it makes sense to go back and change it there as well. 