### PR TITLE
Align TemplateProxy render method to Django Template

### DIFF
--- a/src/template_partials/templatetags/partials.py
+++ b/src/template_partials/templatetags/partials.py
@@ -24,17 +24,18 @@ class TemplateProxy:
         template = self.origin.loader.get_template(self.origin.template_name)
         return template.source
 
+    def _render(self, context):
+        return self.nodelist.render(context)
+
     def render(self, context):
-        """
-        Display stage -- can be called many times
-        """
+        "Display stage -- can be called many times"
         with context.render_context.push_state(self):
             if context.template is None:
                 with context.bind_template(self):
                     context.template_name = self.name
-                    return self.nodelist.render(context)
+                    return self._render(context)
             else:
-                return self.nodelist.render(context)
+                return self._render(context)
 
 
 class DefinePartialNode(template.Node):


### PR DESCRIPTION
Updates TemplateProxy to have _render and render methods similar to those that exist on the Django Template class.

Changes discussed here: https://github.com/carltongibson/django-template-partials/issues/59

I couldn't think of any sensible tests (or at least any tests that added anything of worth) so have not added any. If there is anything you can think of to test let me know and i can get tests added. What its worth (which is probably not much in this case :) ) the methods are both shown as covered in the coverage report.

I've run all the existing tests and they are passing.