### PR TITLE
Fix (short) package description

### DIFF
--- a/src/template_partials/__init__.py
+++ b/src/template_partials/__init__.py
@@ -1,7 +1,5 @@
 """
-django-template-partials
-
-Reusable named inline-partials for the Django Template Language.
+Reusable named inline-partials for the Django Template Language
 """
 
 __version__ = "24.4"


### PR DESCRIPTION
Fix the top docstring in `__init__.py` in order to ensure correct description in package metadata.  `flit-core` is only the first paragraph of the docstring, effectively making the description:

    django-template-partials

Instead, make it:

    Reusable named inline-partials for the Django Template Language

While at it, remove the full stop since it's not a full sentence.