### PR TITLE
Refactor partial_func to improve argument handling 

### DIFF
--- a/src/template_partials/templatetags/partials.py
+++ b/src/template_partials/templatetags/partials.py
@@ -189,13 +189,12 @@ def partial_func(parser, token):
 
         {% partial partial_name %}
     """
-    # Parse the tag
-    try:
-        tag_name, partial_name = token.split_contents()
-    except ValueError:
+    bits = token.split_contents()
+    if len(bits) != 2:
         raise template.TemplateSyntaxError(
-            "%r tag requires a single argument" % tag_name
+            f"'{bits[0]}' tag requires a single argument 'partial_name'"
         )
+    tag_name, partial_name = bits
 
     try:
         extra_data = getattr(parser, "extra_data")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -319,6 +319,21 @@ class PartialTagsTestCase(TestCase):
         ):
             t.render()
 
+    def test_partial_with_no_partial_name(self):
+        """
+        Test that a partial with no partial name raises a TemplateSyntaxError.
+        """
+        template = """
+        {% load partials %}
+        {% partial %}
+        """
+        engine = engines["django"]
+        with self.assertRaisesMessage(
+            TemplateSyntaxError,
+            "'partial' tag requires a single argument 'partial_name'",
+        ):
+            engine.from_string(template)
+
 
 class ChildCachedLoaderTest(TestCase):
     def test_child_cached_loader(self):


### PR DESCRIPTION
Fixes https://github.com/carltongibson/django-template-partials/issues/80

- Simplified argument parsing in partial_func to raise a TemplateSyntaxError when no partial name is provided.
- Added a test case to ensure that the appropriate error message is raised when the partial tag is used without an argument.