### PR TITLE
refactor: fix template partials passing for django 4.2

### DIFF
--- a/src/template_partials/loader.py
+++ b/src/template_partials/loader.py
@@ -51,6 +51,11 @@ class Loader(BaseLoader):
             extra_data = getattr(template, "extra_data")
             partial_contents = extra_data.get("template-partials", {})
         except AttributeError:
+            partial_contents = None
+
+        # NOTE: This is needed at least until the end of life of Django 4.2
+        #       See https://github.com/django-components/django-components/issues/1323#issuecomment-3185252145
+        if partial_contents is None:
             try:
                 partial_contents = template.origin.partial_contents
             except AttributeError:


### PR DESCRIPTION
From https://github.com/django-components/django-components/issues/1323#issuecomment-3185252145:

---

Hi, I've cleaned up the PR for compatibility with template-partials, see https://github.com/django-components/django-components/pull/1328.

But it looks like there's a compatibility issue between template-partials v25.1 and django v4.2.

When the partials are being set, they are set either on the Parser, or on Origin:

<img width="1078" height="356" alt="Image" src="https://github.com/user-attachments/assets/05a6024c-55d0-4c7c-bdac-827b138440c8" />

But the way the partials are being retrieved in the loader seems to be wrong (at least on Django 4.2).

For whatever reason, the Template actually has the `extra_data` field, even though it's empty.

So the branch that checks for the partials definition on the Origin doesn't run. Which leads to an error as the partials definiton is never found

<img width="1085" height="350" alt="Image" src="https://github.com/user-attachments/assets/6e80b02e-4107-4121-8e47-183e0d99ddb1" />

The fix would be to check both `Template.extra_data` and `Template.origin.partial_contents` in `Loader.get_template`:

```py
class Loader(BaseLoader):
    def get_template(self, template_name, skip=None):
        ...

        # From Django 5.1, the template has the extra_data attribute.
        # Use that, falling back to reference on the origin.
        try:
            extra_data = getattr(template, "extra_data")
            partial_contents = extra_data.get("template-partials", {})
        except AttributeError:
            # NEW
            partial_contents = None
        # NEW
        if partial_contents is None:
            try:
                partial_contents = template.origin.partial_contents
            except AttributeError:
                # No partials defined on this template.
                raise TemplateDoesNotExist(partial_name, tried=[template_name])
```

I'll create PR for that shortly