### PR TITLE
Fix import-time crash on Django 6.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+
+* Fix import-time crash on Django 6.0b1 ([Issue #88](https://github.com/carltongibson/django-template-partials/issues/88)).
 
 ## 25.2 (2025-09-17)
 

--- a/src/template_partials/templatetags/partials.py
+++ b/src/template_partials/templatetags/partials.py
@@ -10,8 +10,7 @@ _START_TAG = re.compile(r"\{%\s*(startpartial|partialdef)\s+([\w-]+)(\s+inline)?
 _END_TAG_OLD = re.compile(r"\{%\s*endpartial\s*%}")
 _END_TAG = re.compile(r"\{%\s*endpartialdef\s*%}")
 
-django_version = tuple(map(int, django.__version__.split(".")[:2]))
-if django_version >= (6, 0):
+if django.VERSION >= (6, 0):
     warnings.warn(
         "The 'partial'and 'partialdef' template tags are now part of Django core. "
         "You no longer need to use {% load partials %} as of Django 6.0. \n"


### PR DESCRIPTION
Fixes #88.

Tested with:

```
$ uvx --with django==6.0b1 --with-editable . python -c 'import template_partials.templatetags.partials'
<string>:1: DeprecationWarning: The 'partial'and 'partialdef' template tags are now part of Django core. You no longer need to use {% load partials %} as of Django 6.0.
Visit https://github.com/carltongibson/django-template-partials/blob/main/Migration.md for migration instructions.
```